### PR TITLE
fix: resolve Vercel build error with force-dynamic rendering

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,9 @@ import { AppSidebar } from "@/components/app-sidebar"
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar"
 import { ErrorBoundary } from "@/components/shared/ErrorBoundary"
 
+// Force dynamic rendering to avoid static generation issues
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: "Directors Palette",
   description: "Visual story and music video breakdown tool",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,9 @@
 "use client"
 
 import { useEffect } from "react"
+import dynamic from "next/dynamic"
 import { Button } from "@/components/ui/button"
 import { Plus } from "lucide-react"
-import { ProjectManager } from "@/components/project-manager"
-import { ProjectHeader } from "@/components/shared/ProjectHeader"
 import { AsyncBoundary } from "@/components/shared/AsyncBoundary"
 import { ModeSelector } from "@/components/containers/ModeSelector"
 import { StoryContainer } from "@/components/containers/StoryContainer"
@@ -12,8 +11,14 @@ import { MusicVideoContainer } from "@/components/containers/MusicVideoContainer
 import { useSessionManagement } from "@/hooks/useSessionManagement"
 import { useAppStore } from "@/stores/app-store"
 
+// Dynamically import ProjectManager to avoid SSR issues
+const ProjectManager = dynamic(
+  () => import("@/components/project-manager").then(mod => ({ default: mod.ProjectManager })),
+  { ssr: false }
+)
+
 export default function Home() {
-  const { mode, showProjectManager, setShowProjectManager, currentProjectId, isLoading } = useAppStore()
+  const { mode = "story", showProjectManager = false, setShowProjectManager, currentProjectId, isLoading = false } = useAppStore()
   // Session management hook already loads on mount internally
   useSessionManagement()
 


### PR DESCRIPTION
The build was failing on Vercel with "Cannot read properties of undefined (reading 'find')" during static page generation. This was caused by stores/data being undefined during SSR.

Fixed by:
- Adding force-dynamic export to layout.tsx to prevent static generation
- Adding default values to useAppStore destructuring
- Dynamic import for ProjectManager component
- All pages now render dynamically instead of statically

This ensures the app only renders on the server with full access to stores and data, preventing the undefined errors during build.

🤖 Generated with [Claude Code](https://claude.ai/code)